### PR TITLE
Fixing scientific notation in recommended scaling factors

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '637952'
+ValidationKey: '668976'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'
@@ -8,3 +8,5 @@ AcceptedNotes:
 AutocreateReadme: yes
 allowLinterWarnings: no
 enforceVersionUpdate: no
+AutocreateCITATION: yes
+skipCoverage: no

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -23,26 +23,24 @@ jobs:
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: |
-            any::lucode2
-            any::covr
-            any::madrat
-            any::magclass
-            any::citation
-            any::gms
-            any::goxygen
-            any::GDPuc
+            lucode2
+            covr
+            madrat
+            magclass
+            citation
+            gms
+            goxygen
+            GDPuc
           # piam packages also available on CRAN (madrat, magclass, citation,
           # gms, goxygen, GDPuc) will usually have an outdated binary version
           # available; by using extra-packages we get the newest version
 
-      - uses: actions/setup-python@v5
-        with:
-          python-version: 3.9
-
-      - name: Install python dependencies if applicable
+      - name: Run pre-commit checks
+        shell: bash
         run: |
-          [ -f requirements.txt ] && python -m pip install --upgrade pip wheel || true
-          [ -f requirements.txt ] && pip install -r requirements.txt || true
+          python -m pip install pre-commit
+          python -m pip freeze --local
+          pre-commit run --show-diff-on-failure --color=always --all-files
 
       - name: Verify validation key
         shell: Rscript {0}
@@ -63,6 +61,6 @@ jobs:
         shell: Rscript {0}
         run: |
           nonDummyTests <- setdiff(list.files("./tests/testthat/"), c("test-dummy.R", "_snaps"))
-          if(length(nonDummyTests) > 0) covr::codecov(quiet = FALSE)
+          if(length(nonDummyTests) > 0 && !lucode2:::loadBuildLibraryConfig()[["skipCoverage"]]) covr::codecov(quiet = FALSE)
         env:
           NOT_CRAN: "true"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 exclude: '^tests/testthat/_snaps/.*$'
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: 2c9f875913ee60ca25ce70243dc24d5b6415598c  # frozen: v4.6.0
+    rev: cef0300fd0fc4d2a87a85fa2093c6b283ea36f4b  # frozen: v5.0.0
     hooks:
     -   id: check-case-conflict
     -   id: check-json
@@ -15,7 +15,7 @@ repos:
     -   id: mixed-line-ending
 
 -   repo: https://github.com/lorenzwalthert/precommit
-    rev: 7910e0323d7213f34275a7a562b9ef0fde8ce1b9  # frozen: v0.4.2
+    rev: 3b70240796cdccbe1474b0176560281aaded97e6  # frozen: v0.4.3.9003
     hooks:
     -   id: parsable-R
     -   id: deps-in-desc
@@ -25,4 +25,4 @@ repos:
     -   id: readme-rmd-rendered
     -   id: use-tidy-description
 ci:
-    autoupdate_schedule: quarterly
+    autoupdate_schedule: weekly

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'gdx2: Interface package for GDX files in R'
-version: 0.3.2
-date-released: '2024-08-01'
+version: 0.3.3
+date-released: '2025-07-03'
 abstract: A wrapper package for the gamstransfer package extending its functionality
   and allowing to read GDX files directly in R. It is emulating the basic features
   of the readGDX function in the gdx package but now based on gamstransfer instead

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: gdx2
 Title: Interface package for GDX files in R
-Version: 0.3.2
-Date: 2024-08-01
+Version: 0.3.3
+Date: 2025-07-03
 Authors@R: c(
     person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", 
     comment = c(affiliation = "Potsdam Institute for Climate Impact Research", ORCID = "0000-0002-4309-6431"), role = c("aut","cre")))

--- a/R/calcScaling.R
+++ b/R/calcScaling.R
@@ -8,7 +8,7 @@
 #' the code is returned by the function
 #' @param magnitude The order of magnitude for which variables should be
 #' scaled. All variables with average absolute values which are either below
-#' 10e(-magnitude) or above 10e(magnitude) will be scaled.
+#' 10^(-magnitude) or above 10^(magnitude) will be scaled.
 #' @return A vector with the scaling GAMS code if file=NULL, otherwise nothing
 #' is returned.
 #' @author Jan Philipp Dietrich
@@ -32,7 +32,7 @@ calcScaling <- function(gdx, file = NULL, magnitude = 2) {
       sets <- paste("(", paste(attr(v[[x]], "gdxMetadata")$domain, collapse = ","), ")", sep = "")
     }
     if (oof != -Inf && (oof < -1 * magnitude || oof > 1 * magnitude)) {
-      out <- c(out, paste(x, ".scale", sets, " = 10e", oof, ";", sep = ""))
+      out <- c(out, paste(x, ".scale", sets, " = 1e", oof, ";", sep = ""))
     }
   }
   cat("\n\n")

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Interface package for GDX files in R
 
-R package **gdx2**, version **0.3.2**
+R package **gdx2**, version **0.3.3**
 
-[![CRAN status](https://www.r-pkg.org/badges/version/gdx2)](https://cran.r-project.org/package=gdx2)  [![R build status](https://github.com/pik-piam/gdx2/workflows/check/badge.svg)](https://github.com/pik-piam/gdx2/actions) [![codecov](https://codecov.io/gh/pik-piam/gdx2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/gdx2) [![r-universe](https://pik-piam.r-universe.dev/badges/gdx2)](https://pik-piam.r-universe.dev/builds)
+[![CRAN status](https://www.r-pkg.org/badges/version/gdx2)](https://cran.r-project.org/package=gdx2) [![R build status](https://github.com/pik-piam/gdx2/workflows/check/badge.svg)](https://github.com/pik-piam/gdx2/actions) [![codecov](https://codecov.io/gh/pik-piam/gdx2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/gdx2) [![r-universe](https://pik-piam.r-universe.dev/badges/gdx2)](https://pik-piam.r-universe.dev/builds)
 
 ## Purpose and Functionality
 
@@ -40,16 +40,17 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **gdx2** in publications use:
 
-Dietrich J (2024). _gdx2: Interface package for GDX files in R_. R package version 0.3.2, <https://github.com/pik-piam/gdx2>.
+Dietrich J (2025). "gdx2: Interface package for GDX files in R." Version: 0.3.3, <https://github.com/pik-piam/gdx2>.
 
 A BibTeX entry for LaTeX users is
 
  ```latex
-@Manual{,
+@Misc{,
   title = {gdx2: Interface package for GDX files in R},
   author = {Jan Philipp Dietrich},
-  year = {2024},
-  note = {R package version 0.3.2},
+  date = {2025-07-03},
+  year = {2025},
   url = {https://github.com/pik-piam/gdx2},
+  note = {Version: 0.3.3},
 }
 ```

--- a/man/calcScaling.Rd
+++ b/man/calcScaling.Rd
@@ -14,7 +14,7 @@ the code is returned by the function}
 
 \item{magnitude}{The order of magnitude for which variables should be
 scaled. All variables with average absolute values which are either below
-10e(-magnitude) or above 10e(magnitude) will be scaled.}
+10^(-magnitude) or above 10^(magnitude) will be scaled.}
 }
 \value{
 A vector with the scaling GAMS code if file=NULL, otherwise nothing


### PR DESCRIPTION
The old output recommends scaling factors too big by a factor of 10, due to the mixup of notations.