### PR TITLE
Add scaling recommendations for equations based on level and marginal

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -11,3 +11,5 @@
 ^Makefile$
 ^.*CITATION.cff$
 ^\.git$
+^\.claude$
+^_pkgdown\.yml$

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '811920'
+ValidationKey: '812000'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '812000'
+ValidationKey: '820960'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'
@@ -10,3 +10,4 @@ allowLinterWarnings: no
 enforceVersionUpdate: no
 AutocreateCITATION: yes
 skipCoverage: no
+UsePkgDown: no

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '6880051586'
+ValidationKey: '811760'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '811760'
+ValidationKey: '811920'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '668976'
+ValidationKey: '6880051586'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -9,6 +9,7 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main, master]
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main, master]
 
 jobs:
@@ -59,9 +60,31 @@ jobs:
           lucode2::check(runLinter = FALSE)
 
       - name: Test coverage
+        if: ${{ github.event_name != 'pull_request' }}
         shell: Rscript {0}
         run: |
           nonDummyTests <- setdiff(list.files("./tests/testthat/"), c("test-dummy.R", "_snaps"))
-          if(length(nonDummyTests) > 0 && !lucode2:::loadBuildLibraryConfig()[["skipCoverage"]]) covr::codecov(quiet = FALSE)
+          if(length(nonDummyTests) > 0 && !lucode2:::loadBuildLibraryConfig()[["skipCoverage"]]) {
+            coverage <- covr::package_coverage(quiet = FALSE)
+            # The following function might be unnecessary if r-lib/covr#616 gets merged
+            to_simple_codecov <- function(coverage) {
+              fullLineCoverage <- covr:::per_line(coverage)
+              data <- Map(function(fileCoverage) {
+                resultCoverage <- lapply(fileCoverage$coverage, jsonlite::unbox)
+                names(resultCoverage) <- seq_along(resultCoverage)
+                return(resultCoverage)
+              }, fullLineCoverage)
+              return(jsonlite::toJSON(list("coverage" = data), na = "null"))
+            }
+            writeLines(to_simple_codecov(coverage), "simple-codecov.json")
+          }
         env:
           NOT_CRAN: "true"
+
+      - uses: codecov/codecov-action@v4
+        if: ${{ github.event_name != 'pull_request' }}
+        with:
+          file: ./simple-codecov.json
+          plugin: noop
+          disable_search: true
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,7 +3,7 @@ message: If you use this software, please cite it using the metadata from this f
 type: software
 title: 'gdx2: Interface package for GDX files in R'
 version: 0.4.0
-date-released: '2025-07-25'
+date-released: '2025-07-29'
 abstract: A wrapper package for the gamstransfer package extending its functionality
   and allowing to read GDX files directly in R. It is emulating the basic features
   of the readGDX function in the gdx package but now based on gamstransfer instead

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,7 +3,7 @@ message: If you use this software, please cite it using the metadata from this f
 type: software
 title: 'gdx2: Interface package for GDX files in R'
 version: 0.4.0
-date-released: '2025-07-29'
+date-released: '2025-07-31'
 abstract: A wrapper package for the gamstransfer package extending its functionality
   and allowing to read GDX files directly in R. It is emulating the basic features
   of the readGDX function in the gdx package but now based on gamstransfer instead

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'gdx2: Interface package for GDX files in R'
-version: 0.3.3
-date-released: '2025-07-03'
+version: 0.3.3.9019
+date-released: '2025-07-25'
 abstract: A wrapper package for the gamstransfer package extending its functionality
   and allowing to read GDX files directly in R. It is emulating the basic features
   of the readGDX function in the gdx package but now based on gamstransfer instead

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'gdx2: Interface package for GDX files in R'
-version: 0.3.3.9019
+version: 0.4.0
 date-released: '2025-07-25'
 abstract: A wrapper package for the gamstransfer package extending its functionality
   and allowing to read GDX files directly in R. It is emulating the basic features

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,7 +3,7 @@ message: If you use this software, please cite it using the metadata from this f
 type: software
 title: 'gdx2: Interface package for GDX files in R'
 version: 0.4.0
-date-released: '2025-07-31'
+date-released: '2026-03-12'
 abstract: A wrapper package for the gamstransfer package extending its functionality
   and allowing to read GDX files directly in R. It is emulating the basic features
   of the readGDX function in the gdx package but now based on gamstransfer instead

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Type: Package
 Package: gdx2
 Title: Interface package for GDX files in R
 Version: 0.4.0
-Date: 2025-07-31
+Date: 2026-03-12
 Authors@R: c(
     person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", 
     comment = c(affiliation = "Potsdam Institute for Climate Impact Research", ORCID = "0000-0002-4309-6431"), role = c("aut","cre")))
@@ -19,5 +19,5 @@ Suggests:
     covr
 Encoding: UTF-8
 LazyData: yes
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 Config/Keywords: tool

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Type: Package
 Package: gdx2
 Title: Interface package for GDX files in R
 Version: 0.4.0
-Date: 2025-07-25
+Date: 2025-07-29
 Authors@R: c(
     person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", 
     comment = c(affiliation = "Potsdam Institute for Climate Impact Research", ORCID = "0000-0002-4309-6431"), role = c("aut","cre")))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: gdx2
 Title: Interface package for GDX files in R
-Version: 0.3.3.9019
+Version: 0.4.0
 Date: 2025-07-25
 Authors@R: c(
     person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: gdx2
 Title: Interface package for GDX files in R
-Version: 0.3.3
-Date: 2025-07-03
+Version: 0.3.3.9019
+Date: 2025-07-25
 Authors@R: c(
     person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", 
     comment = c(affiliation = "Potsdam Institute for Climate Impact Research", ORCID = "0000-0002-4309-6431"), role = c("aut","cre")))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Type: Package
 Package: gdx2
 Title: Interface package for GDX files in R
 Version: 0.4.0
-Date: 2025-07-29
+Date: 2025-07-31
 Authors@R: c(
     person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", 
     comment = c(affiliation = "Potsdam Institute for Climate Impact Research", ORCID = "0000-0002-4309-6431"), role = c("aut","cre")))

--- a/R/calcScaling.R
+++ b/R/calcScaling.R
@@ -62,7 +62,7 @@ calcScaling <- function(gdx, file = NULL, magnitude = 2) {# nolint: cyclocomp_li
   v <- readGDX(gdx, type = "Equation", select = list("_field" = "marginal"))
   for (x in names(v)) {
     # calculate order of magnitude (oof)
-    oof <- round(log10(mean(abs(v[[x]]))))
+    oof <- -round(log10(mean(1 / abs(v[[x]] + 1e-6))))
     if (is.nan(oof)) oof <- 0
     cat("\n oof =", oof, "  ", x)
     if (length(attr(v[[x]], "gdxMetadata")$domain) == 0) {

--- a/R/calcScaling.R
+++ b/R/calcScaling.R
@@ -44,7 +44,7 @@ calcScaling <- function(gdx, file = NULL, magnitude = 2) {# nolint: cyclocomp_li
   for (x in names(v)) {
     # calculate order of magnitude (oof)
     if (length(v[[x]]) == 0) next
-    oof <- round(log10(mean(abs(v[[x]]))))
+    oof <- round(mean(log10(abs(v[[x]][v[[x]] != 0]))))
     if (is.nan(oof)) oof <- 0
     cat("\n oof =", oof, "  ", x)
     if (length(attr(v[[x]], "gdxMetadata")$domain) == 0) {

--- a/R/calcScaling.R
+++ b/R/calcScaling.R
@@ -24,7 +24,7 @@ calcScaling <- function(gdx, file = NULL, magnitude = 2) {# nolint: cyclocomp_li
   v <- readGDX(gdx, type = "Variable", select = list("_field" = "level"))
   for (x in names(v)) {
     # calculate order of magnitude (oof)
-    oof <- round(log10(mean(abs(v[[x]]))))
+    oof <- round(mean(log10(abs(v[[x]][abs(v[[x]]) > 1e-7]))))
     if (is.nan(oof)) oof <- 0
     cat("\n oof =", oof, "  ", x)
     if (length(attr(v[[x]], "gdxMetadata")$domain) == 0) {
@@ -44,7 +44,7 @@ calcScaling <- function(gdx, file = NULL, magnitude = 2) {# nolint: cyclocomp_li
   for (x in names(v)) {
     # calculate order of magnitude (oof)
     if (length(v[[x]]) == 0) next
-    oof <- round(mean(log10(abs(v[[x]][v[[x]] != 0]))))
+    oof <- round(mean(log10(abs(v[[x]][abs(v[[x]]) > 1e-7]))))
     if (is.nan(oof)) oof <- 0
     cat("\n oof =", oof, "  ", x)
     if (length(attr(v[[x]], "gdxMetadata")$domain) == 0) {
@@ -62,7 +62,7 @@ calcScaling <- function(gdx, file = NULL, magnitude = 2) {# nolint: cyclocomp_li
   v <- readGDX(gdx, type = "Equation", select = list("_field" = "marginal"))
   for (x in names(v)) {
     # calculate order of magnitude (oof)
-    oof <- round(mean(log10(abs(v[[x]][v[[x]] != 0]))))
+    oof <- round(mean(log10(abs(v[[x]][abs(v[[x]]) > 1e-7]))))
     if (is.nan(oof)) oof <- 0
     cat("\n oof =", oof, "  ", x)
     if (length(attr(v[[x]], "gdxMetadata")$domain) == 0) {

--- a/R/calcScaling.R
+++ b/R/calcScaling.R
@@ -18,9 +18,10 @@
 #' calcScaling("fulldata.gdx")
 #' }
 #' @export
-calcScaling <- function(gdx, file = NULL, magnitude = 2) {
-  v <- readGDX(gdx, type = "Variable", select = list("_field" = "level"))
+calcScaling <- function(gdx, file = NULL, magnitude = 2) {# nolint: cyclocomp_linter
   out <- NULL
+
+  v <- readGDX(gdx, type = "Variable", select = list("_field" = "level"))
   for (x in names(v)) {
     # calculate order of magnitude (oof)
     oof <- round(log10(mean(abs(v[[x]]))))
@@ -36,6 +37,45 @@ calcScaling <- function(gdx, file = NULL, magnitude = 2) {
     }
   }
   cat("\n\n")
+  out <- sort(out)
+
+  out2 <- NULL
+  v <- readGDX(gdx, type = "Equation", select = list("_field" = "level"))
+  for (x in names(v)) {
+    # calculate order of magnitude (oof)
+    if (length(v[[x]]) == 0) next
+    oof <- round(log10(mean(abs(v[[x]]))))
+    if (is.nan(oof)) oof <- 0
+    cat("\n oof =", oof, "  ", x)
+    if (length(attr(v[[x]], "gdxMetadata")$domain) == 0) {
+      sets <- ""
+    } else {
+      sets <- paste("(", paste(attr(v[[x]], "gdxMetadata")$domain, collapse = ","), ")", sep = "")
+    }
+    if (oof != -Inf && (oof < -1 * magnitude || oof > 1 * magnitude)) {
+      out2 <- c(out2, paste(x, ".scale", sets, " = 1e", oof, ";", sep = ""))
+    }
+  }
+  cat("\n\n")
+
+  out3 <- NULL
+  v <- readGDX(gdx, type = "Equation", select = list("_field" = "marginal"))
+  for (x in names(v)) {
+    # calculate order of magnitude (oof)
+    oof <- round(log10(mean(abs(v[[x]]))))
+    if (is.nan(oof)) oof <- 0
+    cat("\n oof =", oof, "  ", x)
+    if (length(attr(v[[x]], "gdxMetadata")$domain) == 0) {
+      sets <- ""
+    } else {
+      sets <- paste("(", paste(attr(v[[x]], "gdxMetadata")$domain, collapse = ","), ")", sep = "")
+    }
+    if (oof != -Inf && (oof < -1 * magnitude || oof > 1 * magnitude)) {
+      out3 <- c(out3, paste(x, ".scale", sets, " = 1e", -oof, ";", sep = ""))
+    }
+  }
+  cat("\n\n")
+  out <- c(out, sort(c(out2, out3)))
 
   if (!is.null(file)) {
     writeLines(out, file)

--- a/R/calcScaling.R
+++ b/R/calcScaling.R
@@ -62,7 +62,7 @@ calcScaling <- function(gdx, file = NULL, magnitude = 2) {# nolint: cyclocomp_li
   v <- readGDX(gdx, type = "Equation", select = list("_field" = "marginal"))
   for (x in names(v)) {
     # calculate order of magnitude (oof)
-    oof <- -round(log10(mean(1 / abs(v[[x]] + 1e-6))))
+    oof <- round(mean(log10(abs(v[[x]][v[[x]] != 0]))))
     if (is.nan(oof)) oof <- 0
     cat("\n oof =", oof, "  ", x)
     if (length(attr(v[[x]], "gdxMetadata")$domain) == 0) {

--- a/R/readGDX.R
+++ b/R/readGDX.R
@@ -124,7 +124,12 @@ readGDX <- function(gdx, ..., format = "simplest", type = NULL, react = "warning
       } else if (m$class == "Alias") {
         if (followAlias) x[[i]] <- readGDX(gdx, x[[i]]$aliasWith, followAlias = TRUE)
       } else {
-        if (m$class == "Variable") {
+        if (m$class == "Variable" || m$class == "Equation") {
+          if (x[[i]]$numberRecords == 0) {
+            print(i)
+            x[[i]] <- 0
+            next
+          }
           # convert data.table into long format
           .long <- function(x) {
             n <- c("level", "marginal", "lower", "upper", "scale")

--- a/R/readGDX.R
+++ b/R/readGDX.R
@@ -126,7 +126,7 @@ readGDX <- function(gdx, ..., format = "simplest", type = NULL, react = "warning
       } else {
         if (m$class == "Variable" || m$class == "Equation") {
           if (x[[i]]$numberRecords == 0) {
-            print(i)
+            # Equations or variables might be listed in the gdx without entries.
             x[[i]] <- 0
             next
           }

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {gdx2: Interface package for GDX files in R},
   author = {Jan Philipp Dietrich},
-  date = {2025-07-25},
+  date = {2025-07-29},
   year = {2025},
   url = {https://github.com/pik-piam/gdx2},
   note = {Version: 0.4.0},

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **gdx2** in publications use:
 
-Dietrich J (2025). "gdx2: Interface package for GDX files in R." Version: 0.4.0, <https://github.com/pik-piam/gdx2>.
+Dietrich J (2026). "gdx2: Interface package for GDX files in R." Version: 0.4.0, <https://github.com/pik-piam/gdx2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,8 +48,8 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {gdx2: Interface package for GDX files in R},
   author = {Jan Philipp Dietrich},
-  date = {2025-07-31},
-  year = {2025},
+  date = {2026-03-12},
+  year = {2026},
   url = {https://github.com/pik-piam/gdx2},
   note = {Version: 0.4.0},
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Interface package for GDX files in R
 
-R package **gdx2**, version **0.3.3.9019**
+R package **gdx2**, version **0.4.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/gdx2)](https://cran.r-project.org/package=gdx2) [![R build status](https://github.com/pik-piam/gdx2/workflows/check/badge.svg)](https://github.com/pik-piam/gdx2/actions) [![codecov](https://codecov.io/gh/pik-piam/gdx2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/gdx2) [![r-universe](https://pik-piam.r-universe.dev/badges/gdx2)](https://pik-piam.r-universe.dev/builds)
 
@@ -40,7 +40,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **gdx2** in publications use:
 
-Dietrich J (2025). "gdx2: Interface package for GDX files in R." Version: 0.3.3.9019, <https://github.com/pik-piam/gdx2>.
+Dietrich J (2025). "gdx2: Interface package for GDX files in R." Version: 0.4.0, <https://github.com/pik-piam/gdx2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -51,6 +51,6 @@ A BibTeX entry for LaTeX users is
   date = {2025-07-25},
   year = {2025},
   url = {https://github.com/pik-piam/gdx2},
-  note = {Version: 0.3.3.9019},
+  note = {Version: 0.4.0},
 }
 ```

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {gdx2: Interface package for GDX files in R},
   author = {Jan Philipp Dietrich},
-  date = {2025-07-29},
+  date = {2025-07-31},
   year = {2025},
   url = {https://github.com/pik-piam/gdx2},
   note = {Version: 0.4.0},

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Interface package for GDX files in R
 
-R package **gdx2**, version **0.3.3**
+R package **gdx2**, version **0.3.3.9019**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/gdx2)](https://cran.r-project.org/package=gdx2) [![R build status](https://github.com/pik-piam/gdx2/workflows/check/badge.svg)](https://github.com/pik-piam/gdx2/actions) [![codecov](https://codecov.io/gh/pik-piam/gdx2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/gdx2) [![r-universe](https://pik-piam.r-universe.dev/badges/gdx2)](https://pik-piam.r-universe.dev/builds)
 
@@ -40,7 +40,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **gdx2** in publications use:
 
-Dietrich J (2025). "gdx2: Interface package for GDX files in R." Version: 0.3.3, <https://github.com/pik-piam/gdx2>.
+Dietrich J (2025). "gdx2: Interface package for GDX files in R." Version: 0.3.3.9019, <https://github.com/pik-piam/gdx2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,9 +48,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {gdx2: Interface package for GDX files in R},
   author = {Jan Philipp Dietrich},
-  date = {2025-07-03},
+  date = {2025-07-25},
   year = {2025},
   url = {https://github.com/pik-piam/gdx2},
-  note = {Version: 0.3.3},
+  note = {Version: 0.3.3.9019},
 }
 ```


### PR DESCRIPTION
Scaling in GAMS seems important for both variables and equations, in order for gradients to be scaled properly as well.

- Scaling based on `level`: If an equation's level is too high (e.g. `q15_food_demand`), CONOPT will repeatedly report losing feasability when reducing the infeasibility threshold, and prioritize fulfilling this equation to high precision over other equations. On the contrary, an equation's level being too low risks accepting high relative error.
- Scaling based on `marginal`: A bit less clear, but the general idea is that the marginal of an equation effectively represents the effect it has on the overall cost being optimized. A high marginal points towards an equation where small changes have big effects (e.g. `q58_peatlandMan`), and vice versa.